### PR TITLE
Git revision info is available in the app again.

### DIFF
--- a/custom-scripts/record-git-info.js
+++ b/custom-scripts/record-git-info.js
@@ -1,0 +1,30 @@
+const dotenv = require("dotenv");
+const fs = require("fs");
+
+const ENV_FILE_NAME = ".env.production.local";
+
+if (fs.existsSync(ENV_FILE_NAME)) {
+  throw new Error(
+    `File '${ENV_FILE_NAME}' already exists and would be overwritten by git commit info.`
+  );
+}
+
+const { execSync } = require("child_process");
+try {
+  const REACT_APP_GIT_REVISION_HASH = execSync("git rev-parse HEAD")
+    .toString()
+    .trim();
+  const REACT_APP_GIT_REVISION_DATE = execSync("git log -1 --format=%cd")
+    .toString()
+    .trim();
+
+  fs.writeFileSync(
+    ENV_FILE_NAME,
+    `
+REACT_APP_GIT_REVISION_HASH=${REACT_APP_GIT_REVISION_HASH}
+REACT_APP_GIT_REVISION_DATE=${REACT_APP_GIT_REVISION_DATE}
+  `
+  );
+} catch (e) {
+  console.error("Cannot determine git revision:", e);
+}

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
   "homepage": "./",
   "scripts": {
     "start": "react-scripts start",
-    "build": "react-scripts build",
+    "build": "node ./custom-scripts/record-git-info.js && react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },


### PR DESCRIPTION
I dropped the git revision info recording by mistake when updating the toolchain (Happened in https://github.com/origam/origam-html/commit/a7d8811ea72144474d8d12921d72a33b600e58b0 , see `scripts/build.js`) .

It was a custom change in build script, which we do not have now, since I wanted to try to continue the development without ejecting *Create React App (CRA)*, keeping the project little bit less messy (read more about ejecting: https://create-react-app.dev/docs/available-scripts/#npm-run-eject).

The feature uses builtin *CRA* capability to project some special environment variables to the code being built / executed as if it would be part of the source code itself. Basically this happens for every environment variable with `REACT_APP_` prefix, which exists during build time. (See https://create-react-app.dev/docs/adding-custom-environment-variables/ for detailed explanation) . 

We read `REACT_APP_GIT_REVISION_HASH` and `REACT_APP_GIT_REVISION_DATE` and store them as `ORIGAM_GIT_REVISION_HASH` and `ORIGAM_GIT_REVISION_DATE` respectively (it happens here: https://github.com/origam/origam-html/blob/4c9ede89529e97dd5852b5a649180a27f475ff80/src/index.tsx#L50). This makes both commit hash and date of the sorce checked out being built to become available in the running app console as well as in the about dialog. When the environment variables are not defined, it states `UNKNOWN`.

As we no longer have the build script directly available, I created the special script `custom-scripts/record-git-info.js` to record the revision info. This script writes aforementioned variables to `.env.production.local`, which is an *env file* (see again https://create-react-app.dev/docs/adding-custom-environment-variables/#what-other-env-files-can-be-used for details). I picked this name, because this particular file is intended to tweak the environment locally to be specific for the machine / user performing the build, it is in `.gitignore` by default and so it shall collide with some env settings least probably (I do not know anyone uses this on the build machine, if so, please let me know).

The script is called right before the building one, see `scripts` section of `package.json` .
