### PR TITLE
FIX: Read only multiline fields in grids displayed horizontal scrollb…

### DIFF
--- a/src/gui/Components/ScreenElements/Editors/TextEditor.module.scss
+++ b/src/gui/Components/ScreenElements/Editors/TextEditor.module.scss
@@ -21,7 +21,19 @@ along with ORIGAM. If not, see <http://www.gnu.org/licenses/>.
 
 .input {
   @include input;
+  overflow-x: hidden;
+}
+
+.scrollY{
   overflow-y: auto;
+}
+
+.noScrollY{
+  overflow-y: hidden;
+}
+
+.wrapText{
+  overflow-wrap: anywhere;
 }
 
 .multiLine{

--- a/src/gui/Components/ScreenElements/Editors/TextEditor.tsx
+++ b/src/gui/Components/ScreenElements/Editors/TextEditor.tsx
@@ -47,6 +47,7 @@ export class TextEditor extends React.Component<{
   maxLength?: number;
   isRichText: boolean;
   customStyle?: any;
+  wrapText: boolean;
   subscribeToFocusManager?: (obj: IFocusAble) => void;
   refocuser?: (cb: () => void) => () => void;
   onChange?(event: any, value: string): void;
@@ -140,6 +141,13 @@ export class TextEditor extends React.Component<{
     );
   }
 
+  getMultilineDivClass() {
+    if(this.props.wrapText){
+      return S.input + " " + S.wrapText;
+    }
+    return S.input + " " + (isMultiLine(this.props.value) ? S.scrollY : S.noScrollY);
+  }
+
   private renderValueTag() {
     const maxLength = this.props.maxLength === 0 ? undefined : this.props.maxLength;
     if (this.props.isRichText) {
@@ -198,7 +206,7 @@ export class TextEditor extends React.Component<{
     if (this.props.isReadOnly) {
       return (
         <div
-          className={S.input}
+          className={this.getMultilineDivClass()}
           onClick={this.props.onClick}
           onDoubleClick={this.props.onDoubleClick}
           onBlur={this.props.onEditorBlur}
@@ -231,6 +239,13 @@ export class TextEditor extends React.Component<{
       );
     }
   }
+}
+
+function isMultiLine(text: string | null){
+  if(text === null || text === undefined){
+    return false;
+  }
+   return text.includes("\n")  || text.includes("\r");
 }
 
 function RichTextEditor(props: {

--- a/src/gui/Workbench/ScreenArea/FormView/FormViewEditor.tsx
+++ b/src/gui/Workbench/ScreenArea/FormView/FormViewEditor.tsx
@@ -151,6 +151,7 @@ export class FormViewEditor extends React.Component<{
             onChange={this.props.onChange}
             onKeyDown={this.makeOnKeyDownCallBack()}
             onClick={undefined}
+            wrapText={true}
             onEditorBlur={this.props.onEditorBlur}
             onAutoUpdate={value => onTextFieldAutoUpdate(this.props.property!, value)}
             isRichText={this.props.isRichText}

--- a/src/gui/Workbench/ScreenArea/TableView/TableViewEditor.tsx
+++ b/src/gui/Workbench/ScreenArea/TableView/TableViewEditor.tsx
@@ -132,6 +132,7 @@ export class TableViewEditor extends React.Component<{
             onChange={this.props.onChange}
             onKeyDown={this.props.onEditorKeyDown}
             onClick={undefined}
+            wrapText={false}
             onDoubleClick={(event) => this.onDoubleClick(event)}
             onEditorBlur={this.props.onEditorBlur}
             isRichText={false}


### PR DESCRIPTION
…ar on column overflow

the scroll bar filled the field and the value was not visible