### PR TITLE
CHG: Tooltips above form fields and labels show both the field text (…

### DIFF
--- a/src/gui/Components/Form/FormField.tsx
+++ b/src/gui/Components/Form/FormField.tsx
@@ -102,14 +102,11 @@ export class FormField extends React.Component<{
   }
 
   getToolTip() {
-    if (this.props.toolTip) {
-      return formatTooltipPlaintext(this.props.toolTip);
-    } else {
-      if(this.toolTip){
-        return formatTooltipPlaintext(this.toolTip)
-      }
-      return undefined;
+    let finalToolTip =  this.props.toolTip ?? "";
+    if(this.toolTip){
+      finalToolTip += "\n" +this.toolTip;
     }
+    return formatTooltipPlaintext(finalToolTip);
   }
 
   render() {


### PR DESCRIPTION
…if overflown) and the help (if specified)